### PR TITLE
Add test case for checking bucket index after completing multipart upload

### DIFF
--- a/ragweed/framework.py
+++ b/ragweed/framework.py
@@ -64,6 +64,9 @@ class RGWRESTAdmin:
         result = self.read_meta_key('bucket.instance:' + bucket_name + ":" + bucket_id)
         return result.data.bucket_info
 
+    def check_bucket_index(self, bucket_name):
+        return self.get_resource('/admin/bucket',{'index' : None, 'bucket':bucket_name})
+
     def get_obj_layout(self, key):
         path = '/' + key.bucket.name + '/' + key.name
         params = {'layout': None}

--- a/ragweed/tests/tests.py
+++ b/ragweed/tests/tests.py
@@ -221,6 +221,34 @@ class r_test_multipart_simple(RTest):
 
         validate_obj(rb, self.r_obj, self.r_crc)
 
+# prepare:
+# init, upload, and complete a multipart object
+# check:
+# part index is removed
+class r_test_multipart_index_versioning(RTest):
+    def init(self):
+        self.obj_size = 18 * 1024 * 1024
+        self.part_size = 5 * 1024 * 1024
+
+    def prepare(self):
+        rb = self.create_bucket()
+        rb.bucket.configure_versioning('true')
+        self.r_obj = 'foo'
+
+        uploader = MultipartUploader(rb, self.r_obj, self.obj_size, self.part_size)
+
+        uploader.prepare()
+        uploader.upload_all()
+        uploader.complete()
+
+    def check(self):
+        for rb in self.get_buckets():
+            break
+        index_check_result = rgwa().check_bucket_index(rb.name)
+        print index_check_result
+
+        eq(0, len(index_check_result))
+
 
 # prepare:
 # init, upload multipart object


### PR DESCRIPTION
When bucket versioning is enabled, completing multipart upload can't remove the part index. The fix is in https://github.com/ceph/ceph/pull/14500. 
Because the bucket check API has a bug, so this test case could work if we merge https://github.com/ceph/ceph/pull/12851.

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>