### PR TITLE
Bucket names cannot contain underscore

### DIFF
--- a/ragweed/framework.py
+++ b/ragweed/framework.py
@@ -294,7 +294,9 @@ class RTest:
 
     def create_bucket(self):
         bid = len(self.r_buckets) + 1
-        rb = suite.zone.create_bucket(suite.get_bucket_name(self._name + '-' + str(bid)))
+        bucket_name =  suite.get_bucket_name(self._name + '.' + str(bid))
+        bucket_name = bucket_name.replace("_", "-")
+        rb = suite.zone.create_bucket(bucket_name)
         self.r_buckets.append(rb)
 
         return rb


### PR DESCRIPTION
As per Amazon s3 spec, bucket names cannot contain
underscore.
https://docs.aws.amazon.com/awscloudtrail/latest/userguide/cloudtrail-s3-bucket-naming-requirements.html

This (along with other naming convention mentioned in the doc) are being
enforced via https://github.com/ceph/ceph/pull/26787

This patch is to correct the bucket name generated in ragweed
tests as well.

Signed-off-by: Soumya Koduri <skoduri@redhat.com>