### PR TITLE
README: added a README.rst and changed example conf

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,63 @@
+===============
+ Ragweed Tests
+===============
+
+This is a set of test that verify functionality for the RGW, and the way it is represented in rados.
+
+This can be used to verify functionality between upgrades.
+
+Tests are run in two phases. In the first phase, (possibly when running against the old version) data is prepared.
+
+In the second phase the representation of that data is then tested (possibly after an upgrade). 
+
+Each of these phases can be executed separately.
+
+For more information on the background of the tests visit: https://www.spinics.net/lists/ceph-devel/msg34636.html
+
+The tests use the Nose test framework. To get started, ensure you have
+the ``virtualenv`` software installed; e.g. on Debian/Ubuntu::
+
+	sudo apt-get install python-virtualenv
+
+and then run::
+
+	./bootstrap
+
+You will need to create a configuration file with the location of the
+service and two different credentials. A sample configuration file named
+``ragweed-example.conf`` has been provided in this repo. 
+
+Once you have that file copied and edited, you can run the tests with::
+
+	RAGWEED_CONF=ragweed.conf RAGWEED_STAGES=prepare,check ./virtualenv/bin/nosetests -v
+
+The phase(s) of the tests are set via ``RAGWEED_STAGES``. The options for ``RAGWEED_STAGES``  are ``prepare`` and ``check``. ``test`` can be used instead of ``check``.
+
+=====================================
+Running Ragweed Tests with vstart.sh
+=====================================
+
+Note: This example assumes the path to the ceph source code is $HOME/ceph.
+
+The ``ragweed-example.conf`` file provided can be can be used to run the ragweed tests on a Ceph cluster started with vstart.
+
+Before the ragweed tests are run a system user must be created on the cluster first. From the ``ceph/build`` directory run::
+
+         $HOME/ceph/build/bin/radosgw-admin -c ceph.conf user create --uid=admin_user --display-name="Admin User" --access-key=accesskey2 --secret-key=secretkey2 --admin
+
+If the system user created is different than the one created above the ``[user system]`` section in the ragweed.conf file much match the created user.
+
+Then run ``$HOME/ceph/build/vstart_environment.sh`` or export the ``LD_LIBRARY_PATH`` and ``PYTHONPATH`` generated in the file ``$HOME/ceph/build/vstart_environment.sh``::
+
+        chmod 775 $HOME/ceph/build/vstart_environment.sh
+        $HOME/ceph/build/vstart_environment.sh
+
+OR::
+
+        export PYTHONPATH=$HOME/ceph/master/src/pybind:$HOME/ceph/master/build/lib/cython_modules/lib.3:$HOME/ceph/master/src/python-common:$PYTHONPATH
+        export LD_LIBRARY_PATH=$HOME/ceph/master/build/lib:$LD_LIBRARY_PATH
+
+Finally run the ragweed tests::
+
+	RAGWEED_CONF=ragweed.conf RAGWEED_STAGES=prepare,check ./virtualenv/bin/nosetests -v
+

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,10 @@ the ``virtualenv`` software installed; e.g. on Debian/Ubuntu::
 
 	sudo apt-get install python-virtualenv
 
+on Fedora/RHEL::
+
+	sudo yum install python3-virtualenv
+
 and then run::
 
 	./bootstrap
@@ -60,4 +64,3 @@ OR::
 Finally run the ragweed tests::
 
 	RAGWEED_CONF=ragweed.conf RAGWEED_STAGES=prepare,check ./virtualenv/bin/nosetests -v
-

--- a/ragweed-example.conf
+++ b/ragweed-example.conf
@@ -2,11 +2,11 @@
 
 [rados]
 
+# config file for ceph cluster, ex: ceph_conf = /home/user_name/ceph/build/ceph.conf
 ceph_conf = <path to ceph.conf>
 
 [rgw]
-## replace with e.g. "localhost" to run against local software
-host = <hostname>
+host = localhost
 
 ## uncomment the port to use something other than 80
 port = 8000
@@ -20,11 +20,11 @@ bucket_prefix = ragweed
 [fixtures]
 
 [user regular]
-user_id = yehsad
-access_key = accesskey1
-secret_key = secret1
+user_id = testid
+access_key = 0555b35654ad1656d804
+secret_key = h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q==
 
 [user system]
+user_id = admin_user
 access_key = accesskey2
 secret_key = secret2
-


### PR DESCRIPTION
Added a README with background on the tests,
instructions on running the tests, and how to
run the tests locally on a Ceph cluster created
by vstart.sh

Signed-off-by: Ali Maredia <amaredia@redhat.com>