### PR TITLE
ragweed: fix teuthology failure related to pip issue 6264

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -29,6 +29,7 @@ virtualenv -p python3 --system-site-packages --distribute virtualenv
 
 # avoid pip bugs
 ./virtualenv/bin/pip install --upgrade pip
+pip3 install --upgrade setuptools cffi  # address pip issue: https://github.com/pypa/pip/issues/6264
 
 # work-around change in pip 1.5
 ./virtualenv/bin/pip install six


### PR DESCRIPTION
refrence of tethology error log:
```
2021-01-02T19:25:59.174 INFO:teuthology.orchestra.run.smithi181.stderr:
AttributeError: module 'setuptools.build_meta' has no attribute
'__legacy__'
2021-01-02T19:25:59.174 INFO:teuthology.orchestra.run.smithi181.stderr:
----------------------------------------
2021-01-02T19:25:59.174
INFO:teuthology.orchestra.run.smithi181.stderr:ERROR: Command errored
out with exit status 1:
/home/ubuntu/cephtest/ragweed/virtualenv/bin/python3
/home/ubuntu/cephtest/ragweed/virtualenv/lib/python3.6/site-packages/pip/
2021-01-02T19:25:59.303 DEBUG:teuthology.orchestra.run:got remote
process result: 1
```
Relevant pip issue: https://github.com/pypa/pip/issues/6264

Fixes: https://tracker.ceph.com/issues/48735

Signed-off-by: Mark Kogan <mkogan@redhat.com>