### PR TITLE
ragweed: fix cffi package installation error

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -29,7 +29,7 @@ virtualenv -p python3 --system-site-packages --distribute virtualenv
 
 # avoid pip bugs
 ./virtualenv/bin/pip install --upgrade pip
-sudo pip3 install --upgrade setuptools cffi  # address pip issue: https://github.com/pypa/pip/issues/6264
+sudo pip3 install --upgrade --trusted-host apt-mirror.front.sepia.ceph.com  setuptools cffi  # address pip issue: https://github.com/pypa/pip/issues/6264
 
 # work-around change in pip 1.5
 ./virtualenv/bin/pip install six


### PR DESCRIPTION
address the following sporadic error
```
2021-01-04T16:12:01.116
INFO:teuthology.orchestra.run.smithi065.stdout:Collecting cffi
2021-01-04T16:12:01.116 INFO:teuthology.orchestra.run.smithi065.stderr:
The repository located at apt-mirror.front.sepia.ceph.com is not a
trusted or secure host and is being ignored. If this repository is
available via HTTPS it is recommended
to use HTTPS instead, otherwise you may silence this warning and allow
it anyways with '--trusted-host apt-mirror.front.sepia.ceph.com'.
2021-01-04T16:12:01.117 INFO:teuthology.orchestra.run.smithi065.stderr:
Could not find a version that satisfies the requirement cffi (from
    versions: )
2021-01-04T16:12:01.117
INFO:teuthology.orchestra.run.smithi065.stderr:No matching distribution
found for cffi
```

Signed-off-by: Mark Kogan <mkogan@redhat.com>