### PR TITLE
ragweed: fix missing ffi.h building '_cffi_backend' extension

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -2,7 +2,7 @@
 set -e
 
 if [ -f /etc/debian_version ]; then
-    for package in python3-pip python3-virtualenv python3-dev libevent-dev libxml2-dev libxslt-dev zlib1g-dev; do
+    for package in python3-pip python3-virtualenv python3-dev libevent-dev libxml2-dev libxslt-dev zlib1g-dev libffi-dev; do
         if [ "$(dpkg --status -- $package 2>/dev/null|sed -n 's/^Status: //p')" != "install ok installed" ]; then
             # add a space after old values
             missing="${missing:+$missing }$package"


### PR DESCRIPTION
fix for:
```
building '_cffi_backend' extension                                                                                                                                       
creating build/temp.linux-x86_64-3.6                                                                                                                                     
creating build/temp.linux-x86_64-3.6/c                                                                                                                                   
x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -DUSE__THR│
EAD -I/usr/include/ffi -I/usr/include/libffi -I/usr/include/python3.6m -c c/_cffi_backend.c -o build/temp.linux-x86_64-3.6/c/_cffi_backend.o
_cffi_backend.c -o build/temp.linux-x86_64-3.6/c/_cffi_backend.o                                                                                                         
c/_cffi_backend.c:13:10: fatal error: ffi.h: No such file or directory                                                                                                   
 #include <ffi.h>                                                                                                                                                        
          ^~~~~~~                                                                                                                                                        
compilation terminated.                                                                                                                                                  
error: command 'x86_64-linux-gnu-gcc' failed with exit status 1                                                                                                          
```

Signed-off-by: Mark Kogan <mkogan@redhat.com>