### PR TITLE
ragweed: fix teuthology failure rel to pip issue 6264, cont.

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,8 +1,9 @@
 #!/bin/sh
+set -x
 set -e
 
 if [ -f /etc/debian_version ]; then
-    for package in python3-pip python3-virtualenv python3-dev libevent-dev libxml2-dev libxslt-dev zlib1g-dev libffi-dev; do
+    for package in python3-pip python3-virtualenv python3-dev libevent-dev libxml2-dev libxslt-dev zlib1g-dev libffi-dev python3-cachecontrol; do
         if [ "$(dpkg --status -- $package 2>/dev/null|sed -n 's/^Status: //p')" != "install ok installed" ]; then
             # add a space after old values
             missing="${missing:+$missing }$package"


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/49017

fix error on ubuntu related to missing cachecontrol module:
```
gibba028.stdout:Installing setuptools, pkg_resources, pip, wheel...
gibba028.stdout:  Complete output from command
/home/ubuntu/cephtes...rtualenv/bin/python3 - setuptools pkg_resources
pip wheel:
gibba028.stdout:  Traceback (most recent call last):
  gibba028.stdout:  File
  "/usr/share/python-wheels/pip-9.0.1-py2.py3-none-any.whl/pip/_vendor/__init__.py",
  line 33, in vendored
  gibba028.stdout:ModuleNotFoundError: No module named
  'pip._vendor.cachecontrol'
```

Signed-off-by: Mark Kogan <mkogan@redhat.com>