### PR TITLE
ragweed: fix teuthology failure rel to pip issue 6264 cont..

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -26,7 +26,7 @@ if [ -f /etc/redhat-release ]; then
     fi
 fi
 
-sudo pip3 install --upgrade --trusted-host apt-mirror.front.sepia.ceph.com  setuptools cffi  # address pip issue: https://github.com/pypa/pip/issues/6264
+sudo pip3 install --upgrade --trusted-host apt-mirror.front.sepia.ceph.com  setuptools cffi cachecontrol # address pip issue: https://github.com/pypa/pip/issues/6264
 virtualenv -p python3 --system-site-packages --distribute virtualenv
 
 # avoid pip bugs


### PR DESCRIPTION
Fixes: https://tracker.ceph.com/issues/49017

cont. fixing missing python module

```
ModuleNotFoundError: No module named
  'pip._vendor.cachecontrol'
```

Signed-off-by: Mark Kogan <mkogan@redhat.com>