### PR TITLE
ragweed: fix teuthology failure related to pip issue 6264

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,8 +1,9 @@
 #!/bin/sh
+set -x
 set -e
 
 if [ -f /etc/debian_version ]; then
-    for package in python3-pip python3-virtualenv python3-dev libevent-dev libxml2-dev libxslt-dev zlib1g-dev; do
+    for package in python3-pip python3-virtualenv python3-dev libevent-dev libxml2-dev libxslt-dev zlib1g-dev libffi-dev python3-cffi python3-pycparser python3-cachecontrol; do
         if [ "$(dpkg --status -- $package 2>/dev/null|sed -n 's/^Status: //p')" != "install ok installed" ]; then
             # add a space after old values
             missing="${missing:+$missing }$package"
@@ -25,7 +26,8 @@ if [ -f /etc/redhat-release ]; then
     fi
 fi
 
-virtualenv -p python3 --system-site-packages --distribute virtualenv
+sudo pip3 install --upgrade --trusted-host apt-mirror.front.sepia.ceph.com  setuptools cffi cachecontrol # address pip issue: https://github.com/pypa/pip/issues/6264
+virtualenv -p python3 --system-site-packages --download --distribute virtualenv
 
 # avoid pip bugs
 ./virtualenv/bin/pip install --upgrade pip


### PR DESCRIPTION
refrence of tethology error log:
```
2021-01-02T19:25:59.174 INFO:teuthology.orchestra.run.smithi181.stderr:
AttributeError: module 'setuptools.build_meta' has no attribute
'__legacy__'
2021-01-02T19:25:59.174 INFO:teuthology.orchestra.run.smithi181.stderr:
----------------------------------------
2021-01-02T19:25:59.174
INFO:teuthology.orchestra.run.smithi181.stderr:ERROR: Command errored
out with exit status 1:
/home/ubuntu/cephtest/ragweed/virtualenv/bin/python3
/home/ubuntu/cephtest/ragweed/virtualenv/lib/python3.6/site-packages/pip/
2021-01-02T19:25:59.303 DEBUG:teuthology.orchestra.run:got remote
process result: 1
```

Signed-off-by: Mark Kogan <mkogan@redhat.com>

ragweed: fix teuthology failure related to pip issue 6264 (add sudo)

Signed-off-by: Mark Kogan <mkogan@redhat.com>

ragweed: fix cffi package installation error

address the following sporadic error
```
2021-01-04T16:12:01.116
INFO:teuthology.orchestra.run.smithi065.stdout:Collecting cffi
2021-01-04T16:12:01.116 INFO:teuthology.orchestra.run.smithi065.stderr:
The repository located at apt-mirror.front.sepia.ceph.com is not a
trusted or secure host and is being ignored. If this repository is
available via HTTPS it is recommended
to use HTTPS instead, otherwise you may silence this warning and allow
it anyways with '--trusted-host apt-mirror.front.sepia.ceph.com'.
2021-01-04T16:12:01.117 INFO:teuthology.orchestra.run.smithi065.stderr:
Could not find a version that satisfies the requirement cffi (from
    versions: )
2021-01-04T16:12:01.117
INFO:teuthology.orchestra.run.smithi065.stderr:No matching distribution
found for cffi
```

Signed-off-by: Mark Kogan <mkogan@redhat.com>

ragweed: fix missing ffi.h building '_cffi_backend' extension

Signed-off-by: Mark Kogan <mkogan@redhat.com>

ragweed: fix teuthology failure - pip issue 6264, cont.

upgrade setuptools pkg before old ver used in venv creation
(b/c of --system-site-packages)

Signed-off-by: Mark Kogan <mkogan@redhat.com>

ragweed: fix teuthology failure rel to pip issue 6264, cont.

Fixes: https://tracker.ceph.com/issues/49017

fix error on ubuntu related to missing cachecontrol module:
```
gibba028.stdout:Installing setuptools, pkg_resources, pip, wheel...
gibba028.stdout:  Complete output from command
/home/ubuntu/cephtes...rtualenv/bin/python3 - setuptools pkg_resources
pip wheel:
gibba028.stdout:  Traceback (most recent call last):
  gibba028.stdout:  File
  "/usr/share/python-wheels/pip-9.0.1-py2.py3-none-any.whl/pip/_vendor/__init__.py",
  line 33, in vendored
  gibba028.stdout:ModuleNotFoundError: No module named
  'pip._vendor.cachecontrol'
```

Signed-off-by: Mark Kogan <mkogan@redhat.com>

ragweed: fix teuthology failure rel to pip issue 6264 cont..

Fixes: https://tracker.ceph.com/issues/49017

cont. fixing missing python module

```
ModuleNotFoundError: No module named
  'pip._vendor.cachecontrol'
```

Signed-off-by: Mark Kogan <mkogan@redhat.com>

ragweed: fix teuthology failure rel to pip issue 6264 keep fixing

Signed-off-by: Mark Kogan <mkogan@redhat.com>

ragweed: fix teuthology failure rel to pip issue 6264 - cffi version

address cffi version mismatch between apt and old ver from local pip
mirror

Signed-off-by: Mark Kogan <mkogan@redhat.com>