### PR TITLE
bootstrap: use python3-venv instead python3-virtualenv

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -3,7 +3,7 @@ set -x
 set -e
 
 if [ -f /etc/debian_version ]; then
-    for package in python3-pip python3-virtualenv python3-dev libevent-dev libxml2-dev libxslt-dev zlib1g-dev libffi-dev python3-cffi python3-pycparser python3-cachecontrol; do
+    for package in python3-pip python3-venv python3-dev libevent-dev libxml2-dev libxslt-dev zlib1g-dev libffi-dev python3-cffi python3-pycparser python3-cachecontrol; do
         if [ "$(dpkg --status -- $package 2>/dev/null|sed -n 's/^Status: //p')" != "install ok installed" ]; then
             # add a space after old values
             missing="${missing:+$missing }$package"
@@ -27,7 +27,7 @@ if [ -f /etc/redhat-release ]; then
 fi
 
 sudo pip3 install --upgrade --trusted-host apt-mirror.front.sepia.ceph.com  setuptools cffi cachecontrol # address pip issue: https://github.com/pypa/pip/issues/6264
-virtualenv -p python3 --system-site-packages --download virtualenv
+python3 -m venv virtualenv
 
 # avoid pip bugs
 ./virtualenv/bin/pip install --upgrade pip


### PR DESCRIPTION
on ubuntu 22.04, the 'virtualenv' command has no virtualenv/bin subdirectory, so bootstrap fails with:
```
./virtualenv/bin/pip: not found
```