### PR TITLE
on ubuntu 20.04 the `python3-distro-info` package causes error

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -13,6 +13,7 @@ if [ -f /etc/debian_version ]; then
         echo "$0: missing required DEB packages. Installing via sudo." 1>&2
         sudo apt-get -y install $missing
     fi
+    sudo apt-get remove -y python3-distro-info
 fi
 if [ -f /etc/redhat-release ]; then
     for package in python3-pip python3-virtualenv python3-devel libevent-devel libxml2-devel libxslt-devel zlib-devel; do


### PR DESCRIPTION
`Invalid version: '0.23ubuntu1' (package: distro-info)` during bootstrap executing the command:
`./virtualenv/bin/python setup.py develop`

(tested on both 20.04 and 22.04, no adverse side effects were seen on 22.04)

ref:
https://bugs.launchpad.net/ubuntu/+source/distro-info/+bug/1991606/comments/18

Fixes: https://tracker.ceph.com/issues/58549

Signed-off-by: mkogan <mkogan@ibm.com>